### PR TITLE
parse arrays correctly in commonjs docs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function objToJson(obj) {
   return Object.keys(obj).reduce(function(memo, key) {
     if (typeof obj[key] === 'function') {
       memo[key] = obj[key].toString();
-    } else if (typeof obj[key] === 'object') {
+    } else if (typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
       memo[key] = objToJson(obj[key]);
     } else {
       memo[key] = obj[key];
@@ -53,7 +53,7 @@ function compileModule(filename, options, callback) {
   if (err) {
     return callback(err);
   }
-  
+
   if (!doc._id) {
     doc._id = idFromFilename(filename, '.js');
   }
@@ -90,7 +90,7 @@ function compileJSON(filename, options, callback) {
 function compileDirectory(dir, options, callback) {
   var doc = {};
   var attachments = [];
-  
+
   function readFile(filename, done) {
     fs.stat(filename, function(err, stats) {
       if (err) {
@@ -238,7 +238,7 @@ module.exports = function compile(source, options, callback) {
         compileDirectory(source, options, callback);
       });
     }
-    
+
     if (!stats.isFile()) {
       return callback({ error: 'not a file: ' + source });
     }

--- a/test/compile-test.js
+++ b/test/compile-test.js
@@ -38,3 +38,12 @@ glob(path.join(FIXTURES_DIR, '{_design/*,_local/*,[^_]*}'), function(err, files)
     }
   });
 });
+
+test('array value from common-js', function (t) {
+  var fixturesPath = path.join(FIXTURES_DIR, 'array-example.js')
+  console.log(fixturesPath)
+  compile(fixturesPath, { index: true }, function (err, doc) {
+    t.ok(Array.isArray(doc.array), 'parses Array correctly')
+    t.end();
+  })
+})

--- a/test/expected/array-example.js.json
+++ b/test/expected/array-example.js.json
@@ -1,0 +1,7 @@
+{
+  "_id": "array-example",
+  "array": [
+    "foo",
+    "bar"
+  ]
+}

--- a/test/fixtures/array-example.js
+++ b/test/fixtures/array-example.js
@@ -1,0 +1,7 @@
+module.exports = {
+  "_id": "array-example",
+  "array": [
+    "foo",
+    "bar"
+  ]
+}


### PR DESCRIPTION
currently, couchdb-compile turns

```json
"array": [
  "foo",
  "bar"
]
```

into 

```json
"array": {
  "0": "foo",
  "1": "bar"
}
```