### PR TITLE
Consistent sort ordering when compiling directories.

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,6 +165,8 @@ function compileDirectory(dir, options, callback) {
       return callback(err);
     }
 
+    filenames.sort();
+
     async.each(filenames, readFile, function(err) {
       if (err) {
         return callback(err);


### PR DESCRIPTION
I'm trying to use couchdb-compile in a project where the product of compilation gets committed back to a git repo. This PR stops the diff churn that happens because `glob()`'s result order is filesystem-dependant.

In other words, it makes the output from couchdb-compile more consistent, and stops this happening over and over:

```diff
@@ -1,9 +1,9 @@
 {
   "_id": "_design/foo",
-  "language": "coffeescript",
   "views": {
     "feed-queue": {
       "map": "..."
     }
-  }
+  },
+  "language": "coffeescript"
 }
```