### PR TITLE
Handle fields with `null` value

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function objToJson (obj) {
   return Object.keys(obj).reduce(function (memo, key) {
     if (typeof obj[key] === 'function') {
       memo[key] = obj[key].toString()
-    } else if (typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+    } else if (typeof obj[key] === 'object' && !Array.isArray(obj[key]) && obj[key] !== null) {
       memo[key] = objToJson(obj[key])
     } else {
       memo[key] = obj[key]

--- a/test/expected/null-example.js.json
+++ b/test/expected/null-example.js.json
@@ -1,0 +1,4 @@
+{
+  "_id": "null-example",
+  "null-field": null
+}

--- a/test/fixtures/null-example.js
+++ b/test/fixtures/null-example.js
@@ -1,0 +1,4 @@
+module.exports = {
+  _id: 'null-example',
+  'null-field': null
+}


### PR DESCRIPTION
Hello and thank you for your valueable work,

I just ran into a problem with a document that includes a field with a `null` value. Digging a little deeper it seems that the `objToJson` function currently doesn't handle fields with a `null` value correctly. This PR includes a test that seems to reproduce this problem. Is this a bug or do I misunderstand the usage?

Regards!